### PR TITLE
Version 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,26 @@
 
 ## 0.0.2 2019/12/03
 ### Bug fix
-- Fixed an error in km_copy_from_work() for transposed matricies.
+- Fixed an error in `km_copy_from_work()` for transposed matricies.
 Linear algebra methods used with transposed output matricies were affected.
 ### New feature
-- Added Mat#geo_mean which returns the geometric mean of self's elements.
-- Added some normalizing methods: Mat#normalize/!, Mat#geo_normalize/! and Mat#svd_symmetrize/!
+- Added` Mat#geo_mean` which returns the geometric mean of self's elements.
+- Added some normalizing methods: `Mat#normalize/!`, `Mat#geo_normalize/!` and `Mat#svd_symmetrize/!`.
 
 ## 0.0.3 2019/12/03
-- Fix a bug in Mat#geo_normalize
+- Fix a bug in {Mat#geo_normalize{.
 
 ## 0.1.0 2022/03/20
 - Conformed newer Ruby regulations.
-	- Not use Random::DEFAULT.
-	- Set rb_data_type_t::dcompact.
-	- Use rb_block_call instead of rb_iterate.
-	- Use RB_BLOCK_CALL_FUNC_ARGLIST.
-- Fixed int/size_t confusion.
-- Fixed a bug that Mat#ge_evd did not return correct right eigen vectors.
+	- Quit using `Random::DEFAULT`.
+	- Set `rb_data_type_t::dcompact`.
+	- Use `rb_block_call` instead of `rb_iterate`.
+	- Use `RB_BLOCK_CALL_FUNC_ARGLIST`.
+- Fixed `int`/`size_t` confusion.
+- Fixed a bug that `Mat#ge_evd` did not return correct right eigen vectors.
 - Fixed some minor bugs.
+
+## 0.1.1 2026/01/07
+- Deprecate the global variable `$MatRandom`.
+	- It is replaced by a class variable `@@random` under the `Mat` class.
+	- The class variable can be obtained by `Mat.random` and can be substituted by `Mat.random=(new_random_instance)`.

--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ Marshal.load(Marshal.dump(a))
 require 'kmat'
 
 Mat.randn(2, 2, random: Random.new) # In kmat, methods using random value, the generator can be specified by keyword `random'
-$MatRandom = Random.new             # Or substitute into $MatRandom
+Mat.random = Random.new             # Or substitute the class variable
 Random.new.randn                    # Random#randn returns a random value following N(0, 1)
-randn()                             # Kernel#randn is equivalent to $MatRandom.randn
+randn()                             # Kernel#randn is equivalent to Mat.random.randn
 ```
 
 

--- a/ext/kmat/extconf.rb
+++ b/ext/kmat/extconf.rb
@@ -15,7 +15,6 @@ end
 $CFLAGS = "$(cflags) -std=c11"
 $CFLAGS += " -m64" if mkl
 
-#$warnflags = "-Wall -Wextra -Wdeprecated-declarations -Wimplicit-function-declaration -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wmissing-noreturn -Wno-unused-parameter -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wunused-variable -Wno-maybe-uninitialized -Winit-self -Wshadow"
 $warnflags = "-Wall -Wextra -Wdeprecated-declarations -Wimplicit-function-declaration -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wmissing-noreturn -Wno-unused-parameter -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wunused-variable -Winit-self -Wshadow -Wlogical-op -Wconversion"
 
 $DLDFLAGS += " -Wl,-Bsymbolic -fPIC"

--- a/ext/kmat/id.txt
+++ b/ext/kmat/id.txt
@@ -41,6 +41,7 @@ op_pow **
 op_uminus -@
 quo
 rand
+random
 real
 to_c
 to_s

--- a/ext/kmat/lapack_headers/blas.h
+++ b/ext/kmat/lapack_headers/blas.h
@@ -351,4 +351,3 @@ void ztrsm_(char *side, char *uplo, char *trans, char *diag, int *m, int *n,
 #endif
 
 #endif
-

--- a/ext/kmat/smat/boxmuller.c
+++ b/ext/kmat/smat/boxmuller.c
@@ -63,10 +63,20 @@ km_random_randn(int argc, VALUE *argv, VALUE random)
 	}
 }
 
+VALUE
+kmm_Mat__set_random(VALUE self, VALUE other)
+{
+	if ( rb_obj_is_kind_of(other, rb_cRandom) ) {
+		kmgv_mat_random = other;
+		return kmgv_mat_random;
+	} else {
+		rb_raise(rb_eTypeError, "the argument must be an Random, not %s", rb_obj_classname(other));
+	}
+}
+
 void
 km_Mat_rand_init(void)
 {
-	kmgv_mat_random = rb_funcall(rb_cRandom, id_new, 0);
-	rb_define_variable("$MatRandom", &kmgv_mat_random);
+	kmgv_mat_random = rb_funcall(km_cMat, id_random, 0);
 	rb_define_method(rb_cRandom, "randn", km_random_randn, -1);
 }

--- a/lib/kmat.rb
+++ b/lib/kmat.rb
@@ -2,6 +2,13 @@ require_relative "./kmat/version"
 
 class Mat
 	include Enumerable
+	@@random = Random.new
+	def self.random
+		@@random
+	end
+	def self.random=(other)
+		@@random = _set_random(other)
+	end
 end
 
 class << Mat

--- a/lib/kmat/linalg.rb
+++ b/lib/kmat/linalg.rb
@@ -63,10 +63,10 @@ class Mat
 		Mat.new(self.col_size, 1, :f).wls!(self, b, w)
 	end
 	
-	def rand_orth(random: $MatRandom)
+	def rand_orth(random: @@andom)
 		_rand_orth(random)
 	end
-	def self.rand_orth(n, random: $MatRandom)
+	def self.rand_orth(n, random: @@andom)
 		Mat.new(n, n, :float).rand_orth(random: random)
 	end
 	
@@ -275,4 +275,3 @@ class Mat
 		end
 	end
 end
-

--- a/lib/kmat/random.rb
+++ b/lib/kmat/random.rb
@@ -78,7 +78,7 @@ class << Random
 		kmat_srand_org(*args)
 	end
 	def randn(*args)
-		$MatRandom.randn(*args)
+		Mat.random.randn(*args)
 	end
 end
 
@@ -89,18 +89,18 @@ module Kernel
 end
 
 class Mat
-	def rand(arg=nil, random: $MatRandom)
+	def rand(arg=nil, random: @@random)
 		_rand0(random, arg)
 	end
-	def randn(random: $MatRandom)
+	def randn(random: @@random)
 		_randn0(random)
 	end
 end
 class << Mat
-	def rand(m=1, n=1, random: $MatRandom)
+	def rand(m=1, n=1, random: self.random)
 		_rand0(m, n, random)
 	end
-	def randn(m=1, n=1, random: $MatRandom)
+	def randn(m=1, n=1, random: self.random)
 		_randn0(m, n, random)
 	end
 end

--- a/lib/kmat/version.rb
+++ b/lib/kmat/version.rb
@@ -1,3 +1,3 @@
 class Mat
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,6 +96,6 @@ begin
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-  $MatRandom = Random.new(config.seed)
+  Mat.random = Random.new(config.seed)
 end
 end


### PR DESCRIPTION
## 0.1.1 2026/01/07
- Deprecate the global variable `$MatRandom`.
	- It is replaced by a class variable `@@random` under the `Mat` class.
	- The class variable can be obtained by `Mat.random` and can be substituted by `Mat.random=(new_random_instance)`.